### PR TITLE
style: bump ruff target-version to py311 and modernize annotations

### DIFF
--- a/kenallclient/__main__.py
+++ b/kenallclient/__main__.py
@@ -4,7 +4,6 @@ import sys
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable
 from pprint import pprint
-from typing import Dict, Type
 
 from .client import KenAllClient
 
@@ -19,11 +18,11 @@ class Command(metaclass=ABCMeta):
         pass
 
 
-commands: Dict[str, Command] = {}
+commands: dict[str, Command] = {}
 
 
-def command(name: str) -> Callable[[Type[Command]], Type[Command]]:
-    def _(typ: Type[Command]) -> Type[Command]:
+def command(name: str) -> Callable[[type[Command]], type[Command]]:
+    def _(typ: type[Command]) -> type[Command]:
         commands[name] = typ()
         return typ
 

--- a/kenallclient/client.py
+++ b/kenallclient/client.py
@@ -2,7 +2,7 @@ import json
 import re
 import urllib.parse
 import urllib.request
-from typing import Dict, List, Literal, Optional, Tuple, overload
+from typing import Literal, overload
 
 from kenallclient.models import (
     compatible,
@@ -51,25 +51,23 @@ def normalize_postal_code(postal_code: str) -> str:
 
 class KenAllClient:
     api_url = "https://api.kenall.jp"
-    api_version: Optional[APIVersion] = None
+    api_version: APIVersion | None = None
 
     def __init__(
         self,
         api_key: str,
-        api_url: Optional[str] = None,
+        api_url: str | None = None,
     ) -> None:
         self.api_key = api_key
         if api_url is not None:
             self.api_url = api_url
 
     @property
-    def authorization(self) -> Dict[str, str]:
+    def authorization(self) -> dict[str, str]:
         auth = {"Authorization": f"Token {self.api_key}"}
         return auth
 
-    def _build_headers(
-        self, api_version: Optional[APIVersion] = None
-    ) -> Dict[str, str]:
+    def _build_headers(self, api_version: APIVersion | None = None) -> dict[str, str]:
         headers = self.authorization.copy()
         version = api_version or self.api_version
         if version:
@@ -83,7 +81,7 @@ class KenAllClient:
         postal_code: str,
         api_version: Literal["2022-11-01"] = ...,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> v20221101.AddressResolverResponse: ...
 
     @overload
@@ -92,7 +90,7 @@ class KenAllClient:
         postal_code: str,
         api_version: Literal["2023-09-01"] = ...,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> v20230901.AddressResolverResponse: ...
 
     @overload
@@ -101,7 +99,7 @@ class KenAllClient:
         postal_code: str,
         api_version: Literal["2024-01-01"] = ...,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> v20240101.AddressResolverResponse: ...
 
     @overload
@@ -110,7 +108,7 @@ class KenAllClient:
         postal_code: str,
         api_version: Literal["2025-01-01"] = ...,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> v20250101.AddressResolverResponse: ...
 
     @overload
@@ -119,7 +117,7 @@ class KenAllClient:
         postal_code: str,
         api_version: Literal["2026-08-01"] = ...,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> v20260801.AddressResolverResponse: ...
 
     @overload
@@ -128,15 +126,15 @@ class KenAllClient:
         postal_code: str,
         api_version: None = None,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> compatible.AddressResolverResponse: ...
 
     def get(
         self,
         postal_code: str,
-        api_version: Optional[APIVersion] = None,
+        api_version: APIVersion | None = None,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ):
         """Get address information by postal code
 
@@ -151,12 +149,12 @@ class KenAllClient:
     def search(
         self,
         *,
-        q: Optional[str] = None,
-        t: Optional[str] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet: Optional[str] = None,
-        version: Optional[str] = None,
+        q: str | None = None,
+        t: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet: str | None = None,
+        version: str | None = None,
         api_version: Literal["2022-11-01"] = ...,
     ) -> v20221101.AddressSearcherResponse: ...
 
@@ -164,12 +162,12 @@ class KenAllClient:
     def search(
         self,
         *,
-        q: Optional[str] = None,
-        t: Optional[str] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet: Optional[str] = None,
-        version: Optional[str] = None,
+        q: str | None = None,
+        t: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet: str | None = None,
+        version: str | None = None,
         api_version: Literal["2023-09-01"] = ...,
     ) -> v20230901.AddressSearcherResponse: ...
 
@@ -177,12 +175,12 @@ class KenAllClient:
     def search(
         self,
         *,
-        q: Optional[str] = None,
-        t: Optional[str] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet: Optional[str] = None,
-        version: Optional[str] = None,
+        q: str | None = None,
+        t: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet: str | None = None,
+        version: str | None = None,
         api_version: Literal["2024-01-01"] = ...,
     ) -> v20240101.AddressSearcherResponse: ...
 
@@ -190,12 +188,12 @@ class KenAllClient:
     def search(
         self,
         *,
-        q: Optional[str] = None,
-        t: Optional[str] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet: Optional[str] = None,
-        version: Optional[str] = None,
+        q: str | None = None,
+        t: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet: str | None = None,
+        version: str | None = None,
         api_version: Literal["2025-01-01"] = ...,
     ) -> v20250101.AddressSearcherResponse: ...
 
@@ -203,12 +201,12 @@ class KenAllClient:
     def search(
         self,
         *,
-        q: Optional[str] = None,
-        t: Optional[str] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet: Optional[str] = None,
-        version: Optional[str] = None,
+        q: str | None = None,
+        t: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet: str | None = None,
+        version: str | None = None,
         api_version: Literal["2026-08-01"] = ...,
     ) -> v20260801.AddressSearcherResponse: ...
 
@@ -216,25 +214,25 @@ class KenAllClient:
     def search(
         self,
         *,
-        q: Optional[str] = None,
-        t: Optional[str] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet: Optional[str] = None,
-        version: Optional[str] = None,
+        q: str | None = None,
+        t: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet: str | None = None,
+        version: str | None = None,
         api_version: None = None,
     ) -> compatible.AddressSearcherResponse: ...
 
     def search(
         self,
         *,
-        q: Optional[str] = None,
-        t: Optional[str] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet: Optional[str] = None,
-        version: Optional[str] = None,
-        api_version: Optional[APIVersion] = None,
+        q: str | None = None,
+        t: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet: str | None = None,
+        version: str | None = None,
+        api_version: APIVersion | None = None,
     ):
         """Search addresses
 
@@ -261,7 +259,7 @@ class KenAllClient:
         prefecture_code: str,
         api_version: Literal["2022-11-01"] = ...,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> v20221101.CityResolverResponse: ...
 
     @overload
@@ -270,7 +268,7 @@ class KenAllClient:
         prefecture_code: str,
         api_version: Literal["2023-09-01"] = ...,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> v20230901.CityResolverResponse: ...
 
     @overload
@@ -279,7 +277,7 @@ class KenAllClient:
         prefecture_code: str,
         api_version: Literal["2024-01-01"] = ...,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> v20240101.CityResolverResponse: ...
 
     @overload
@@ -288,7 +286,7 @@ class KenAllClient:
         prefecture_code: str,
         api_version: Literal["2025-01-01"] = ...,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> v20250101.CityResolverResponse: ...
 
     @overload
@@ -297,7 +295,7 @@ class KenAllClient:
         prefecture_code: str,
         api_version: Literal["2026-08-01"] = ...,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> v20260801.CityResolverResponse: ...
 
     @overload
@@ -306,15 +304,15 @@ class KenAllClient:
         prefecture_code: str,
         api_version: None = None,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> compatible.CityResolverResponse: ...
 
     def get_cities(
         self,
         prefecture_code: str,
-        api_version: Optional[APIVersion] = None,
+        api_version: APIVersion | None = None,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ):
         """Get the cities that belong to the prefecture
 
@@ -345,7 +343,7 @@ class KenAllClient:
         self, houjinbangou: str, api_version: None = None
     ) -> compatible.NTACorporateInfoResolverResponse: ...
 
-    def get_houjin(self, houjinbangou: str, api_version: Optional[APIVersion] = None):
+    def get_houjin(self, houjinbangou: str, api_version: APIVersion | None = None):
         """Get corporate info by houjinbangou"""
         req = self.create_houjin_request(houjinbangou, api_version)
         return self.fetch_houjin_result(req, api_version)
@@ -354,13 +352,13 @@ class KenAllClient:
     def search_houjin(
         self,
         q: str,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        mode: Optional[str] = None,
-        facet_area: Optional[str] = None,
-        facet_kind: Optional[str] = None,
-        facet_process: Optional[str] = None,
-        facet_close_cause: Optional[str] = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        mode: str | None = None,
+        facet_area: str | None = None,
+        facet_kind: str | None = None,
+        facet_process: str | None = None,
+        facet_close_cause: str | None = None,
         api_version: Literal["2024-01-01"] = ...,
     ) -> v20240101.NTACorporateInfoSearcherResponse: ...
 
@@ -368,13 +366,13 @@ class KenAllClient:
     def search_houjin(
         self,
         q: str,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        mode: Optional[str] = None,
-        facet_area: Optional[str] = None,
-        facet_kind: Optional[str] = None,
-        facet_process: Optional[str] = None,
-        facet_close_cause: Optional[str] = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        mode: str | None = None,
+        facet_area: str | None = None,
+        facet_kind: str | None = None,
+        facet_process: str | None = None,
+        facet_close_cause: str | None = None,
         api_version: Literal["2025-01-01"] = ...,
     ) -> v20250101.NTACorporateInfoSearcherResponse: ...
 
@@ -382,13 +380,13 @@ class KenAllClient:
     def search_houjin(
         self,
         q: str,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        mode: Optional[str] = None,
-        facet_area: Optional[str] = None,
-        facet_kind: Optional[str] = None,
-        facet_process: Optional[str] = None,
-        facet_close_cause: Optional[str] = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        mode: str | None = None,
+        facet_area: str | None = None,
+        facet_kind: str | None = None,
+        facet_process: str | None = None,
+        facet_close_cause: str | None = None,
         api_version: Literal["2026-08-01"] = ...,
     ) -> v20260801.NTACorporateInfoSearcherResponse: ...
 
@@ -396,27 +394,27 @@ class KenAllClient:
     def search_houjin(
         self,
         q: str,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        mode: Optional[str] = None,
-        facet_area: Optional[str] = None,
-        facet_kind: Optional[str] = None,
-        facet_process: Optional[str] = None,
-        facet_close_cause: Optional[str] = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        mode: str | None = None,
+        facet_area: str | None = None,
+        facet_kind: str | None = None,
+        facet_process: str | None = None,
+        facet_close_cause: str | None = None,
         api_version: None = None,
     ) -> compatible.NTACorporateInfoSearcherResponse: ...
 
     def search_houjin(
         self,
         q: str,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        mode: Optional[str] = None,
-        facet_area: Optional[str] = None,
-        facet_kind: Optional[str] = None,
-        facet_process: Optional[str] = None,
-        facet_close_cause: Optional[str] = None,
-        api_version: Optional[APIVersion] = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        mode: str | None = None,
+        facet_area: str | None = None,
+        facet_kind: str | None = None,
+        facet_process: str | None = None,
+        facet_close_cause: str | None = None,
+        api_version: APIVersion | None = None,
     ):
         """Search corporate info"""
         req = self.create_houjin_search_request(
@@ -454,7 +452,7 @@ class KenAllClient:
     ) -> compatible.NTAQualifiedInvoiceIssuerInfoResolverResponse: ...
 
     def get_invoice_issuer(
-        self, issuer_number: str, api_version: Optional[APIVersion] = None
+        self, issuer_number: str, api_version: APIVersion | None = None
     ):
         """Get qualified invoice issuer info by issuer number"""
         req = self.create_invoice_issuer_request(issuer_number, api_version)
@@ -463,10 +461,10 @@ class KenAllClient:
     # Holiday search (same across all versions)
     def search_holiday(
         self,
-        year: Optional[int] = None,
-        from_: Optional[str] = None,
-        to: Optional[str] = None,
-        api_version: Optional[APIVersion] = None,
+        year: int | None = None,
+        from_: str | None = None,
+        to: str | None = None,
+        api_version: APIVersion | None = None,
     ) -> HolidaySearchResult:
         """Search holidays"""
 
@@ -477,7 +475,7 @@ class KenAllClient:
 
     # Business day check (same across all versions)
     def check_business_day(
-        self, date: str, api_version: Optional[APIVersion] = None
+        self, date: str, api_version: APIVersion | None = None
     ) -> BusinessDayCheckResponse:
         """Tell whether the date is a business day
 
@@ -488,7 +486,7 @@ class KenAllClient:
         return self.fetch_business_day_check_result(req, api_version)
 
     # Whoami (same across all versions)
-    def whoami(self, api_version: Optional[APIVersion] = None) -> WhoamiResponse:
+    def whoami(self, api_version: APIVersion | None = None) -> WhoamiResponse:
         """Get the IP address the request was made from"""
         req = self.create_whoami_request(api_version)
         return self.fetch_whoami_result(req, api_version)
@@ -517,7 +515,7 @@ class KenAllClient:
     @overload
     def get_banks(self, api_version: None = None) -> compatible.BanksResponse: ...
 
-    def get_banks(self, api_version: Optional[APIVersion] = None):
+    def get_banks(self, api_version: APIVersion | None = None):
         """Get all banks"""
         req = self.create_banks_request(api_version)
         return self.fetch_banks_result(req, api_version)
@@ -527,10 +525,10 @@ class KenAllClient:
     def search_banks(
         self,
         *,
-        q: Optional[str] = None,
-        match: Optional[BankSearchMatchMode] = None,
-        type: Optional[BankType] = None,
-        version: Optional[str] = None,
+        q: str | None = None,
+        match: BankSearchMatchMode | None = None,
+        type: BankType | None = None,
+        version: str | None = None,
         api_version: Literal["2026-08-01"] = ...,
     ) -> v20260801.BanksResponse: ...
 
@@ -538,21 +536,21 @@ class KenAllClient:
     def search_banks(
         self,
         *,
-        q: Optional[str] = None,
-        match: Optional[BankSearchMatchMode] = None,
-        type: Optional[BankType] = None,
-        version: Optional[str] = None,
+        q: str | None = None,
+        match: BankSearchMatchMode | None = None,
+        type: BankType | None = None,
+        version: str | None = None,
         api_version: None = None,
     ) -> compatible.BanksResponse: ...
 
     def search_banks(
         self,
         *,
-        q: Optional[str] = None,
-        match: Optional[BankSearchMatchMode] = None,
-        type: Optional[BankType] = None,
-        version: Optional[str] = None,
-        api_version: Optional[BankSearchAPIVersion] = None,
+        q: str | None = None,
+        match: BankSearchMatchMode | None = None,
+        type: BankType | None = None,
+        version: str | None = None,
+        api_version: BankSearchAPIVersion | None = None,
     ):
         """Search banks by name, by kana reading, or by institution category
 
@@ -602,7 +600,7 @@ class KenAllClient:
         self, bank_code: str, api_version: None = None
     ) -> compatible.BankResolverResponse: ...
 
-    def get_bank(self, bank_code: str, api_version: Optional[APIVersion] = None):
+    def get_bank(self, bank_code: str, api_version: APIVersion | None = None):
         """Get specific bank"""
         req = self.create_bank_request(bank_code, api_version)
         return self.fetch_bank_result(req, api_version)
@@ -632,9 +630,7 @@ class KenAllClient:
         self, bank_code: str, api_version: None = None
     ) -> compatible.BankBranchesResponse: ...
 
-    def get_bank_branches(
-        self, bank_code: str, api_version: Optional[APIVersion] = None
-    ):
+    def get_bank_branches(self, bank_code: str, api_version: APIVersion | None = None):
         """Get branches for a bank"""
         req = self.create_bank_branches_request(bank_code, api_version)
         return self.fetch_bank_branches_result(req, api_version)
@@ -645,9 +641,9 @@ class KenAllClient:
         self,
         bank_code: str,
         *,
-        q: Optional[str] = None,
-        match: Optional[BankSearchMatchMode] = None,
-        version: Optional[str] = None,
+        q: str | None = None,
+        match: BankSearchMatchMode | None = None,
+        version: str | None = None,
         api_version: Literal["2026-08-01"] = ...,
     ) -> v20260801.BankBranchesResponse: ...
 
@@ -656,9 +652,9 @@ class KenAllClient:
         self,
         bank_code: str,
         *,
-        q: Optional[str] = None,
-        match: Optional[BankSearchMatchMode] = None,
-        version: Optional[str] = None,
+        q: str | None = None,
+        match: BankSearchMatchMode | None = None,
+        version: str | None = None,
         api_version: None = None,
     ) -> compatible.BankBranchesResponse: ...
 
@@ -666,10 +662,10 @@ class KenAllClient:
         self,
         bank_code: str,
         *,
-        q: Optional[str] = None,
-        match: Optional[BankSearchMatchMode] = None,
-        version: Optional[str] = None,
-        api_version: Optional[BankSearchAPIVersion] = None,
+        q: str | None = None,
+        match: BankSearchMatchMode | None = None,
+        version: str | None = None,
+        api_version: BankSearchAPIVersion | None = None,
     ):
         """Search the branches of a bank by name or by kana reading
 
@@ -716,7 +712,7 @@ class KenAllClient:
     ) -> compatible.BankBranchResolverResponse: ...
 
     def get_bank_branch(
-        self, bank_code: str, branch_code: str, api_version: Optional[APIVersion] = None
+        self, bank_code: str, branch_code: str, api_version: APIVersion | None = None
     ):
         """Get specific branch"""
         req = self.create_bank_branch_request(bank_code, branch_code, api_version)
@@ -726,9 +722,9 @@ class KenAllClient:
     def create_request(
         self,
         postal_code: str,
-        api_version: Optional[APIVersion] = None,
+        api_version: APIVersion | None = None,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> urllib.request.Request:
         """Create request for postal code lookup"""
         url = urllib.parse.urljoin(
@@ -741,16 +737,16 @@ class KenAllClient:
     def create_address_search_request(
         self,
         *,
-        q: Optional[str] = None,
-        t: Optional[str] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet: Optional[str] = None,
-        version: Optional[str] = None,
-        api_version: Optional[APIVersion] = None,
+        q: str | None = None,
+        t: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet: str | None = None,
+        version: str | None = None,
+        api_version: APIVersion | None = None,
     ) -> urllib.request.Request:
         """Create request for address search"""
-        query_mapping: List[Tuple[str, Optional[str]]] = [
+        query_mapping: list[tuple[str, str | None]] = [
             ("q", q),
             ("t", t),
             ("offset", str(offset) if offset is not None else None),
@@ -765,9 +761,7 @@ class KenAllClient:
         url = f"{self.api_url}/v1/postalcode/?{query}"
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
-    def fetch(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
-    ):
+    def fetch(self, req: urllib.request.Request, api_version: APIVersion | None = None):
         """Backward compatibility method for tests"""
         with urllib.request.urlopen(req) as res:
             if not res.headers["Content-Type"].startswith("application/json"):
@@ -777,7 +771,7 @@ class KenAllClient:
         return create_address_resolver_response(d, api_version)
 
     def fetch_address_search_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ):
         """Fetch address search result with version awareness"""
         with urllib.request.urlopen(req) as res:
@@ -788,7 +782,7 @@ class KenAllClient:
         return create_address_searcher_response(d, api_version)
 
     def create_houjin_request(
-        self, houjinbangou: str, api_version: Optional[APIVersion] = None
+        self, houjinbangou: str, api_version: APIVersion | None = None
     ) -> urllib.request.Request:
         """Backward compatibility method for tests"""
         url = f"{self.api_url}/v1/houjinbangou/{houjinbangou}"
@@ -797,17 +791,17 @@ class KenAllClient:
     def create_houjin_search_request(
         self,
         q: str,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        mode: Optional[str] = None,
-        facet_area: Optional[str] = None,
-        facet_kind: Optional[str] = None,
-        facet_process: Optional[str] = None,
-        facet_close_cause: Optional[str] = None,
-        api_version: Optional[APIVersion] = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        mode: str | None = None,
+        facet_area: str | None = None,
+        facet_kind: str | None = None,
+        facet_process: str | None = None,
+        facet_close_cause: str | None = None,
+        api_version: APIVersion | None = None,
     ) -> urllib.request.Request:
         """Create request for houjin search"""
-        query_mapping: List[Tuple[str, Optional[str]]] = [
+        query_mapping: list[tuple[str, str | None]] = [
             ("q", q),
             ("offset", str(offset) if offset is not None else None),
             ("limit", str(limit) if limit is not None else None),
@@ -831,7 +825,7 @@ class KenAllClient:
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
     def fetch_houjin_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ):
         """Backward compatibility method for tests"""
         with urllib.request.urlopen(req) as res:
@@ -842,7 +836,7 @@ class KenAllClient:
         return create_corporate_info_resolver_response(d, api_version)
 
     def fetch_search_houjin_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ):
         """Backward compatibility method for tests"""
         with urllib.request.urlopen(req) as res:
@@ -853,14 +847,14 @@ class KenAllClient:
         return create_corporate_info_searcher_response(d, api_version)
 
     def create_invoice_issuer_request(
-        self, issuer_number: str, api_version: Optional[APIVersion] = None
+        self, issuer_number: str, api_version: APIVersion | None = None
     ) -> urllib.request.Request:
         """Create request for qualified invoice issuer lookup"""
         url = f"{self.api_url}/v1/invoice/{issuer_number}"
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
     def fetch_invoice_issuer_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ):
         """Fetch invoice issuer result with version awareness"""
         with urllib.request.urlopen(req) as res:
@@ -871,14 +865,14 @@ class KenAllClient:
         return create_invoice_issuer_resolver_response(d, api_version)
 
     def create_whoami_request(
-        self, api_version: Optional[APIVersion] = None
+        self, api_version: APIVersion | None = None
     ) -> urllib.request.Request:
         """Create request for whoami"""
         url = f"{self.api_url}/v1/whoami"
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
     def fetch_whoami_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ) -> WhoamiResponse:
         """Fetch whoami result"""
         with urllib.request.urlopen(req) as res:
@@ -889,7 +883,7 @@ class KenAllClient:
         return WhoamiResponse.fromdict(d)
 
     def create_business_day_check_request(
-        self, date: str, api_version: Optional[APIVersion] = None
+        self, date: str, api_version: APIVersion | None = None
     ) -> urllib.request.Request:
         """Create request for business day check"""
         query = urllib.parse.urlencode([("date", date)])
@@ -897,7 +891,7 @@ class KenAllClient:
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
     def fetch_business_day_check_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ) -> BusinessDayCheckResponse:
         """Fetch business day check result"""
         with urllib.request.urlopen(req) as res:
@@ -908,7 +902,7 @@ class KenAllClient:
         return BusinessDayCheckResponse.fromdict(d)
 
     def fetch_search_holiday_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ):
         """Backward compatibility method for tests"""
         with urllib.request.urlopen(req) as res:
@@ -922,13 +916,13 @@ class KenAllClient:
 
     def create_holiday_search_request(
         self,
-        year: Optional[int] = None,
-        from_date: Optional[str] = None,
-        to_date: Optional[str] = None,
-        api_version: Optional[APIVersion] = None,
+        year: int | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        api_version: APIVersion | None = None,
     ) -> urllib.request.Request:
         """Create request for holiday search"""
-        query_mapping: List[Tuple[str, Optional[str]]] = [
+        query_mapping: list[tuple[str, str | None]] = [
             ("year", str(year) if year is not None else None),
             ("from", from_date),
             ("to", to_date),
@@ -943,9 +937,9 @@ class KenAllClient:
     def create_city_request(
         self,
         city_code: str,
-        api_version: Optional[APIVersion] = None,
+        api_version: APIVersion | None = None,
         *,
-        version: Optional[str] = None,
+        version: str | None = None,
     ) -> urllib.request.Request:
         """Create request for city lookup"""
         url = f"{self.api_url}/v1/cities/{city_code}"
@@ -954,7 +948,7 @@ class KenAllClient:
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
     def fetch_city_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ):
         """Fetch city result with version awareness"""
         with urllib.request.urlopen(req) as res:
@@ -966,14 +960,14 @@ class KenAllClient:
 
     # Bank API helper methods
     def create_banks_request(
-        self, api_version: Optional[APIVersion] = None
+        self, api_version: APIVersion | None = None
     ) -> urllib.request.Request:
         """Create request for getting all banks"""
         url = f"{self.api_url}/v1/bank"
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
     def fetch_banks_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ):
         """Fetch banks result with version awareness"""
         with urllib.request.urlopen(req) as res:
@@ -986,14 +980,14 @@ class KenAllClient:
     def create_bank_search_request(
         self,
         *,
-        q: Optional[str] = None,
-        match: Optional[BankSearchMatchMode] = None,
-        type: Optional[BankType] = None,
-        version: Optional[str] = None,
-        api_version: Optional[BankSearchAPIVersion] = None,
+        q: str | None = None,
+        match: BankSearchMatchMode | None = None,
+        type: BankType | None = None,
+        version: str | None = None,
+        api_version: BankSearchAPIVersion | None = None,
     ) -> urllib.request.Request:
         """Create request for bank search"""
-        query_mapping: List[Tuple[str, Optional[str]]] = [
+        query_mapping: list[tuple[str, str | None]] = [
             ("q", q),
             ("match", match),
             ("type", type),
@@ -1009,14 +1003,14 @@ class KenAllClient:
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
     def create_bank_request(
-        self, bank_code: str, api_version: Optional[APIVersion] = None
+        self, bank_code: str, api_version: APIVersion | None = None
     ) -> urllib.request.Request:
         """Create request for getting specific bank"""
         url = f"{self.api_url}/v1/bank/{bank_code}"
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
     def fetch_bank_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ):
         """Fetch bank result with version awareness"""
         with urllib.request.urlopen(req) as res:
@@ -1027,7 +1021,7 @@ class KenAllClient:
         return create_bank_resolver_response(d, api_version)
 
     def create_bank_branches_request(
-        self, bank_code: str, api_version: Optional[APIVersion] = None
+        self, bank_code: str, api_version: APIVersion | None = None
     ) -> urllib.request.Request:
         """Create request for getting bank branches"""
         url = f"{self.api_url}/v1/bank/{bank_code}/branches"
@@ -1037,13 +1031,13 @@ class KenAllClient:
         self,
         bank_code: str,
         *,
-        q: Optional[str] = None,
-        match: Optional[BankSearchMatchMode] = None,
-        version: Optional[str] = None,
-        api_version: Optional[BankSearchAPIVersion] = None,
+        q: str | None = None,
+        match: BankSearchMatchMode | None = None,
+        version: str | None = None,
+        api_version: BankSearchAPIVersion | None = None,
     ) -> urllib.request.Request:
         """Create request for bank branch search"""
-        query_mapping: List[Tuple[str, Optional[str]]] = [
+        query_mapping: list[tuple[str, str | None]] = [
             ("q", q),
             ("match", match),
             ("version", version),
@@ -1058,7 +1052,7 @@ class KenAllClient:
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
     def fetch_bank_branches_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ):
         """Fetch bank branches result with version awareness"""
         with urllib.request.urlopen(req) as res:
@@ -1069,14 +1063,14 @@ class KenAllClient:
         return create_bank_branches_response(d, api_version)
 
     def create_bank_branch_request(
-        self, bank_code: str, branch_code: str, api_version: Optional[APIVersion] = None
+        self, bank_code: str, branch_code: str, api_version: APIVersion | None = None
     ) -> urllib.request.Request:
         """Create request for getting specific bank branch"""
         url = f"{self.api_url}/v1/bank/{bank_code}/branches/{branch_code}"
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
     def fetch_bank_branch_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ):
         """Fetch bank branch result with version awareness"""
         with urllib.request.urlopen(req) as res:
@@ -1102,7 +1096,7 @@ class KenAllClient:
         self, school_code: str, api_version: None = None
     ) -> v20250101.SchoolResolverResponse: ...
 
-    def get_school(self, school_code: str, api_version: Optional[APIVersion] = None):
+    def get_school(self, school_code: str, api_version: APIVersion | None = None):
         """Get school information by school code"""
         req = self.create_school_request(school_code, api_version)
         return self.fetch_school_result(req, api_version)
@@ -1111,13 +1105,13 @@ class KenAllClient:
     def search_school(
         self,
         q: str,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet_area: Optional[str] = None,
-        facet_prefecture: Optional[str] = None,
-        facet_type: Optional[str] = None,
-        facet_establishment_type: Optional[str] = None,
-        facet_branch: Optional[str] = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet_area: str | None = None,
+        facet_prefecture: str | None = None,
+        facet_type: str | None = None,
+        facet_establishment_type: str | None = None,
+        facet_branch: str | None = None,
         api_version: Literal["2025-01-01"] = ...,
     ) -> v20250101.SchoolSearcherResponse: ...
 
@@ -1125,13 +1119,13 @@ class KenAllClient:
     def search_school(
         self,
         q: str,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet_area: Optional[str] = None,
-        facet_prefecture: Optional[str] = None,
-        facet_type: Optional[str] = None,
-        facet_establishment_type: Optional[str] = None,
-        facet_branch: Optional[str] = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet_area: str | None = None,
+        facet_prefecture: str | None = None,
+        facet_type: str | None = None,
+        facet_establishment_type: str | None = None,
+        facet_branch: str | None = None,
         api_version: Literal["2026-08-01"] = ...,
     ) -> v20260801.SchoolSearcherResponse: ...
 
@@ -1139,27 +1133,27 @@ class KenAllClient:
     def search_school(
         self,
         q: str,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet_area: Optional[str] = None,
-        facet_prefecture: Optional[str] = None,
-        facet_type: Optional[str] = None,
-        facet_establishment_type: Optional[str] = None,
-        facet_branch: Optional[str] = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet_area: str | None = None,
+        facet_prefecture: str | None = None,
+        facet_type: str | None = None,
+        facet_establishment_type: str | None = None,
+        facet_branch: str | None = None,
         api_version: None = None,
     ) -> v20250101.SchoolSearcherResponse: ...
 
     def search_school(
         self,
         q: str,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet_area: Optional[str] = None,
-        facet_prefecture: Optional[str] = None,
-        facet_type: Optional[str] = None,
-        facet_establishment_type: Optional[str] = None,
-        facet_branch: Optional[str] = None,
-        api_version: Optional[APIVersion] = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet_area: str | None = None,
+        facet_prefecture: str | None = None,
+        facet_type: str | None = None,
+        facet_establishment_type: str | None = None,
+        facet_branch: str | None = None,
+        api_version: APIVersion | None = None,
     ):
         """Search school information"""
         req = self.create_school_search_request(
@@ -1177,14 +1171,14 @@ class KenAllClient:
 
     # School API helper methods
     def create_school_request(
-        self, school_code: str, api_version: Optional[APIVersion] = None
+        self, school_code: str, api_version: APIVersion | None = None
     ) -> urllib.request.Request:
         """Create request for school lookup"""
         url = f"{self.api_url}/v1/school/{school_code}"
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
     def fetch_school_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ):
         """Fetch school result with version awareness"""
         with urllib.request.urlopen(req) as res:
@@ -1197,17 +1191,17 @@ class KenAllClient:
     def create_school_search_request(
         self,
         q: str,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        facet_area: Optional[str] = None,
-        facet_prefecture: Optional[str] = None,
-        facet_type: Optional[str] = None,
-        facet_establishment_type: Optional[str] = None,
-        facet_branch: Optional[str] = None,
-        api_version: Optional[APIVersion] = None,
+        offset: int | None = None,
+        limit: int | None = None,
+        facet_area: str | None = None,
+        facet_prefecture: str | None = None,
+        facet_type: str | None = None,
+        facet_establishment_type: str | None = None,
+        facet_branch: str | None = None,
+        api_version: APIVersion | None = None,
     ) -> urllib.request.Request:
         """Create request for school search"""
-        query_mapping: List[Tuple[str, Optional[str]]] = [
+        query_mapping: list[tuple[str, str | None]] = [
             ("q", q),
             ("offset", str(offset) if offset is not None else None),
             ("limit", str(limit) if limit is not None else None),
@@ -1232,7 +1226,7 @@ class KenAllClient:
         return urllib.request.Request(url, headers=self._build_headers(api_version))
 
     def fetch_school_search_result(
-        self, req: urllib.request.Request, api_version: Optional[APIVersion] = None
+        self, req: urllib.request.Request, api_version: APIVersion | None = None
     ):
         """Fetch school search result with version awareness"""
         with urllib.request.urlopen(req) as res:

--- a/kenallclient/models/compatible.py
+++ b/kenallclient/models/compatible.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 from collections.abc import Sequence
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from . import APIVersion
 from .v20230901 import (
@@ -53,12 +53,12 @@ class Corporation:
     name: str
     name_kana: str
     block_lot: str
-    block_lot_num: Optional[str]
+    block_lot_num: str | None
     post_office: str
     code_type: int
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "Corporation":
+    def fromdict(cls, d: dict[str, Any]) -> "Corporation":
         return cls(**d)
 
 
@@ -66,12 +66,12 @@ class Corporation:
 class NTACorporateInfoFacetResults:
     """Facet results for corporate info (base class for compatibility)"""
 
-    area: Optional[List[Tuple[str, int]]]
-    kind: Optional[List[Tuple[str, int]]]
-    process: Optional[List[Tuple[str, int]]]
-    close_cause: Optional[List[Tuple[str, int]]]
+    area: list[tuple[str, int]] | None
+    kind: list[tuple[str, int]] | None
+    process: list[tuple[str, int]] | None
+    close_cause: list[tuple[str, int]] | None
 
-    def __getitem__(self, v: Any) -> List[Tuple[str, int]]:
+    def __getitem__(self, v: Any) -> list[tuple[str, int]]:
         if v == "area":
             if self.area is not None:
                 return self.area
@@ -98,7 +98,7 @@ class NTACorporateInfoFacetResults:
         return False
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTACorporateInfoFacetResults":
+    def fromdict(cls, d: dict[str, Any]) -> "NTACorporateInfoFacetResults":
         return cls(
             area=[tuple(pair) for pair in d["area"]] if "area" in d else None,
             kind=[tuple(pair) for pair in d["kind"]] if "kind" in d else None,
@@ -133,27 +133,27 @@ class Address:
     town_chome: bool
     town_multi: bool
     town_raw: str
-    corporation: Optional[Corporation]
+    corporation: Corporation | None
 
     # Fields added in v20221101 (made optional for compatibility)
-    prefecture_roman: Optional[str] = None
-    city_roman: Optional[str] = None
-    county: Optional[str] = None
-    county_kana: Optional[str] = None
-    county_roman: Optional[str] = None
-    city_without_county_and_ward: Optional[str] = None
-    city_without_county_and_ward_kana: Optional[str] = None
-    city_without_county_and_ward_roman: Optional[str] = None
-    city_ward: Optional[str] = None
-    city_ward_kana: Optional[str] = None
-    city_ward_roman: Optional[str] = None
-    town_roman: Optional[str] = None
-    town_jukyohyoji: Optional[bool] = None
-    update_status: Optional[int] = None
-    update_reason: Optional[int] = None
+    prefecture_roman: str | None = None
+    city_roman: str | None = None
+    county: str | None = None
+    county_kana: str | None = None
+    county_roman: str | None = None
+    city_without_county_and_ward: str | None = None
+    city_without_county_and_ward_kana: str | None = None
+    city_without_county_and_ward_roman: str | None = None
+    city_ward: str | None = None
+    city_ward_kana: str | None = None
+    city_ward_roman: str | None = None
+    town_roman: str | None = None
+    town_jukyohyoji: bool | None = None
+    update_status: int | None = None
+    update_reason: int | None = None
 
     @classmethod
-    def fromdict(cls, i: Dict[str, Any]) -> "Address":
+    def fromdict(cls, i: dict[str, Any]) -> "Address":
         # Create a copy to avoid modifying the original
         data = dict(i)
 
@@ -173,10 +173,10 @@ class AddressResolverResponse:
     """Compatible Address resolver response"""
 
     version: str
-    data: List[Address]
+    data: list[Address]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "AddressResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "AddressResolverResponse":
         data = [Address.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)
 
@@ -186,15 +186,15 @@ class AddressSearcherResponse:
     """Compatible Address searcher response"""
 
     version: str
-    data: List[Address]
+    data: list[Address]
     query: str
     count: int
-    offset: Optional[int]
-    limit: Optional[int]
-    facets: Optional[List[Tuple[str, int]]]
+    offset: int | None
+    limit: int | None
+    facets: list[tuple[str, int]] | None
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "AddressSearcherResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "AddressSearcherResponse":
         data = [Address.fromdict(i) for i in d["data"]]
         dd = dict(d)
         dd["data"] = data
@@ -218,11 +218,11 @@ class City:
     city_kana: str
 
     # Fields added in v20221101 (made optional for compatibility)
-    prefecture_roman: Optional[str] = None
-    city_roman: Optional[str] = None
+    prefecture_roman: str | None = None
+    city_roman: str | None = None
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "City":
+    def fromdict(cls, d: dict[str, Any]) -> "City":
         # Filter out only the fields that exist in the class
         field_names = {f.name for f in dataclasses.fields(cls)}
         filtered_data = {k: v for k, v in d.items() if k in field_names}
@@ -234,10 +234,10 @@ class CityResolverResponse:
     """Compatible City resolver response"""
 
     version: str
-    data: List[City]
+    data: list[City]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "CityResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "CityResolverResponse":
         data = [City.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)
 
@@ -252,7 +252,7 @@ class Holiday:
     day_of_week_text: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "Holiday":
+    def fromdict(cls, d: dict[str, Any]) -> "Holiday":
         return cls(**d)
 
 
@@ -260,10 +260,10 @@ class Holiday:
 class HolidaySearchResult:
     """Holiday search result (same across all versions)"""
 
-    data: List[Holiday]
+    data: list[Holiday]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "HolidaySearchResult":
+    def fromdict(cls, d: dict[str, Any]) -> "HolidaySearchResult":
         data = [Holiday.fromdict(i) for i in d["data"]]
         return HolidaySearchResult(data=data)
 
@@ -275,7 +275,7 @@ class BusinessDayCheckResponse:
     result: bool
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BusinessDayCheckResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BusinessDayCheckResponse":
         return cls(result=d["result"])
 
 
@@ -289,7 +289,7 @@ class RemoteAddress:
     address: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "RemoteAddress":
+    def fromdict(cls, d: dict[str, Any]) -> "RemoteAddress":
         return cls(**d)
 
 
@@ -300,7 +300,7 @@ class WhoamiResponse:
     remote_addr: RemoteAddress
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "WhoamiResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "WhoamiResponse":
         return cls(remote_addr=RemoteAddress.fromdict(d["remote_addr"]))
 
 
@@ -315,37 +315,37 @@ class NTACorporateInfo:
     update_date: str
     change_date: str
     name: str
-    name_image_id: Optional[str]
+    name_image_id: str | None
     kind: int
     prefecture_name: str
     city_name: str
     published_date: str
     hihyoji: int
     furigana: str
-    en_address_outside: Optional[str]
-    en_address_line: Optional[str]
+    en_address_outside: str | None
+    en_address_line: str | None
     en_prefecture_name: str
     en_name: str
     assignment_date: str
     change_cause: str
-    successor_corporate_number: Optional[str]
-    close_cause: Optional[str]
-    close_date: Optional[str]
-    address_outside_image_id: Optional[str]
+    successor_corporate_number: str | None
+    close_cause: str | None
+    close_date: str | None
+    address_outside_image_id: str | None
     address_outside: str
     post_code: str
     jisx0402: str
-    address_image_id: Optional[str]
+    address_image_id: str | None
     street_number: str
-    town: Optional[str]
-    kyoto_street: Optional[str]
-    block_lot_num: Optional[str]
-    building: Optional[str]
-    floor_room: Optional[str]
+    town: str | None
+    kyoto_street: str | None
+    block_lot_num: str | None
+    building: str | None
+    floor_room: str | None
 
     @classmethod
     def fromdict(
-        cls, d: Dict[str, Any], api_version: Optional[APIVersion] = None
+        cls, d: dict[str, Any], api_version: APIVersion | None = None
     ) -> "NTACorporateInfo":
         # Determine the data format based on structure, not the API version
         # v2025-01-01+ uses nested address object, earlier versions use flat structure
@@ -405,7 +405,7 @@ class NTACorporateInfoResolverResponse:
 
     @classmethod
     def fromdict(
-        cls, d: Dict[str, Any], api_version: Optional[APIVersion] = None
+        cls, d: dict[str, Any], api_version: APIVersion | None = None
     ) -> "NTACorporateInfoResolverResponse":
         return cls(
             version=d["version"], data=NTACorporateInfo.fromdict(d["data"], api_version)
@@ -417,7 +417,7 @@ class NTACorporateInfoSearcherResponse:
     """Compatible searcher response (no conversion needed for search results)"""
 
     version: str
-    data: List[NTACorporateInfo]
+    data: list[NTACorporateInfo]
     query: str
     count: int
     offset: int
@@ -426,7 +426,7 @@ class NTACorporateInfoSearcherResponse:
 
     @classmethod
     def fromdict(
-        cls, d: Dict[str, Any], api_version: Optional[APIVersion] = None
+        cls, d: dict[str, Any], api_version: APIVersion | None = None
     ) -> "NTACorporateInfoSearcherResponse":
         dd = dict(d)
         dd["facets"] = NTACorporateInfoFacetResults.fromdict(dd.get("facets") or {})
@@ -439,11 +439,11 @@ class BankBranchesResponse:
     """Compatible bank branches response that flattens the nested structure"""
 
     version: str
-    data: Dict[str, List[BankBranch]]
+    data: dict[str, list[BankBranch]]
 
     @classmethod
     def fromdict(
-        cls, d: Dict[str, Any], api_version: Optional[APIVersion] = None
+        cls, d: dict[str, Any], api_version: APIVersion | None = None
     ) -> "BankBranchesResponse":
         # Parse using the version-specific model
         # Infer API version from data structure if not provided
@@ -479,11 +479,11 @@ class BankBranchResolverResponse:
     """Compatible bank branch resolver response that flattens the nested structure"""
 
     version: str
-    data: List[BankBranch]
+    data: list[BankBranch]
 
     @classmethod
     def fromdict(
-        cls, d: Dict[str, Any], api_version: Optional[APIVersion] = None
+        cls, d: dict[str, Any], api_version: APIVersion | None = None
     ) -> "BankBranchResolverResponse":
         # Parse using the version-specific model
         # Infer API version from data structure if not provided

--- a/kenallclient/models/factories.py
+++ b/kenallclient/models/factories.py
@@ -1,6 +1,6 @@
 """Factory functions for creating version-specific model instances from JSON payloads"""
 
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 from kenallclient.types import APIVersion
 
@@ -15,15 +15,15 @@ from . import (
 
 
 def create_address_resolver_response(
-    data: Dict[str, Any], api_version: Optional[APIVersion] = None
-) -> Union[
-    v20221101.AddressResolverResponse,
-    v20230901.AddressResolverResponse,
-    v20240101.AddressResolverResponse,
-    v20250101.AddressResolverResponse,
-    v20260801.AddressResolverResponse,
-    compatible.AddressResolverResponse,
-]:
+    data: dict[str, Any], api_version: APIVersion | None = None
+) -> (
+    v20221101.AddressResolverResponse
+    | v20230901.AddressResolverResponse
+    | v20240101.AddressResolverResponse
+    | v20250101.AddressResolverResponse
+    | v20260801.AddressResolverResponse
+    | compatible.AddressResolverResponse
+):
     """Create an AddressResolverResponse instance for the specified API version"""
     if api_version == "2022-11-01":
         return v20221101.AddressResolverResponse.fromdict(data)
@@ -40,15 +40,15 @@ def create_address_resolver_response(
 
 
 def create_address_searcher_response(
-    data: Dict[str, Any], api_version: Optional[APIVersion] = None
-) -> Union[
-    v20221101.AddressSearcherResponse,
-    v20230901.AddressSearcherResponse,
-    v20240101.AddressSearcherResponse,
-    v20250101.AddressSearcherResponse,
-    v20260801.AddressSearcherResponse,
-    compatible.AddressSearcherResponse,
-]:
+    data: dict[str, Any], api_version: APIVersion | None = None
+) -> (
+    v20221101.AddressSearcherResponse
+    | v20230901.AddressSearcherResponse
+    | v20240101.AddressSearcherResponse
+    | v20250101.AddressSearcherResponse
+    | v20260801.AddressSearcherResponse
+    | compatible.AddressSearcherResponse
+):
     """Create an AddressSearcherResponse instance for the specified API version"""
     if api_version == "2022-11-01":
         return v20221101.AddressSearcherResponse.fromdict(data)
@@ -65,15 +65,15 @@ def create_address_searcher_response(
 
 
 def create_city_resolver_response(
-    data: Dict[str, Any], api_version: Optional[APIVersion] = None
-) -> Union[
-    v20221101.CityResolverResponse,
-    v20230901.CityResolverResponse,
-    v20240101.CityResolverResponse,
-    v20250101.CityResolverResponse,
-    v20260801.CityResolverResponse,
-    compatible.CityResolverResponse,
-]:
+    data: dict[str, Any], api_version: APIVersion | None = None
+) -> (
+    v20221101.CityResolverResponse
+    | v20230901.CityResolverResponse
+    | v20240101.CityResolverResponse
+    | v20250101.CityResolverResponse
+    | v20260801.CityResolverResponse
+    | compatible.CityResolverResponse
+):
     """Create a CityResolverResponse instance for the specified API version"""
     if api_version == "2022-11-01":
         return v20221101.CityResolverResponse.fromdict(data)
@@ -90,13 +90,13 @@ def create_city_resolver_response(
 
 
 def create_corporate_info_resolver_response(
-    data: Dict[str, Any], api_version: Optional[APIVersion] = None
-) -> Union[
-    v20240101.NTACorporateInfoResolverResponse,
-    v20250101.NTACorporateInfoResolverResponse,
-    v20260801.NTACorporateInfoResolverResponse,
-    compatible.NTACorporateInfoResolverResponse,
-]:
+    data: dict[str, Any], api_version: APIVersion | None = None
+) -> (
+    v20240101.NTACorporateInfoResolverResponse
+    | v20250101.NTACorporateInfoResolverResponse
+    | v20260801.NTACorporateInfoResolverResponse
+    | compatible.NTACorporateInfoResolverResponse
+):
     """Create a NTACorporateInfoResolverResponse for the specified API version"""
     if api_version == "2022-11-01":
         return v20240101.NTACorporateInfoResolverResponse.fromdict(data)
@@ -114,13 +114,13 @@ def create_corporate_info_resolver_response(
 
 
 def create_corporate_info_searcher_response(
-    data: Dict[str, Any], api_version: Optional[APIVersion] = None
-) -> Union[
-    v20240101.NTACorporateInfoSearcherResponse,
-    v20250101.NTACorporateInfoSearcherResponse,
-    v20260801.NTACorporateInfoSearcherResponse,
-    compatible.NTACorporateInfoSearcherResponse,
-]:
+    data: dict[str, Any], api_version: APIVersion | None = None
+) -> (
+    v20240101.NTACorporateInfoSearcherResponse
+    | v20250101.NTACorporateInfoSearcherResponse
+    | v20260801.NTACorporateInfoSearcherResponse
+    | compatible.NTACorporateInfoSearcherResponse
+):
     """Create a NTACorporateInfoSearcherResponse for the specified API version"""
     if api_version == "2022-11-01":
         return v20240101.NTACorporateInfoSearcherResponse.fromdict(data)
@@ -138,14 +138,14 @@ def create_corporate_info_searcher_response(
 
 
 def create_banks_response(
-    data: Dict[str, Any], api_version: Optional[APIVersion] = None
-) -> Union[
-    v20230901.BanksResponse,
-    v20240101.BanksResponse,
-    v20250101.BanksResponse,
-    v20260801.BanksResponse,
-    compatible.BanksResponse,
-]:
+    data: dict[str, Any], api_version: APIVersion | None = None
+) -> (
+    v20230901.BanksResponse
+    | v20240101.BanksResponse
+    | v20250101.BanksResponse
+    | v20260801.BanksResponse
+    | compatible.BanksResponse
+):
     """Create a BanksResponse instance for the specified API version"""
     # Bank API only available from 2023-09-01
     if api_version == "2023-09-01":
@@ -163,14 +163,14 @@ def create_banks_response(
 
 
 def create_bank_resolver_response(
-    data: Dict[str, Any], api_version: Optional[APIVersion] = None
-) -> Union[
-    v20230901.BankResolverResponse,
-    v20240101.BankResolverResponse,
-    v20250101.BankResolverResponse,
-    v20260801.BankResolverResponse,
-    compatible.BankResolverResponse,
-]:
+    data: dict[str, Any], api_version: APIVersion | None = None
+) -> (
+    v20230901.BankResolverResponse
+    | v20240101.BankResolverResponse
+    | v20250101.BankResolverResponse
+    | v20260801.BankResolverResponse
+    | compatible.BankResolverResponse
+):
     """Create a BankResolverResponse instance for the specified API version"""
     # Bank API only available from 2023-09-01
     if api_version == "2023-09-01":
@@ -188,14 +188,14 @@ def create_bank_resolver_response(
 
 
 def create_bank_branches_response(
-    data: Dict[str, Any], api_version: Optional[APIVersion] = None
-) -> Union[
-    v20230901.BankBranchesResponse,
-    v20240101.BankBranchesResponse,
-    v20250101.BankBranchesResponse,
-    v20260801.BankBranchesResponse,
-    compatible.BankBranchesResponse,
-]:
+    data: dict[str, Any], api_version: APIVersion | None = None
+) -> (
+    v20230901.BankBranchesResponse
+    | v20240101.BankBranchesResponse
+    | v20250101.BankBranchesResponse
+    | v20260801.BankBranchesResponse
+    | compatible.BankBranchesResponse
+):
     """Create a BankBranchesResponse instance for the specified API version"""
     # Bank API only available from 2023-09-01.
     # Note that the payload itself changed in 2025-01-01: a branch code maps to
@@ -215,14 +215,14 @@ def create_bank_branches_response(
 
 
 def create_bank_branch_resolver_response(
-    data: Dict[str, Any], api_version: Optional[APIVersion] = None
-) -> Union[
-    v20230901.BankBranchResolverResponse,
-    v20240101.BankBranchResolverResponse,
-    v20250101.BankBranchResolverResponse,
-    v20260801.BankBranchResolverResponse,
-    compatible.BankBranchResolverResponse,
-]:
+    data: dict[str, Any], api_version: APIVersion | None = None
+) -> (
+    v20230901.BankBranchResolverResponse
+    | v20240101.BankBranchResolverResponse
+    | v20250101.BankBranchResolverResponse
+    | v20260801.BankBranchResolverResponse
+    | compatible.BankBranchResolverResponse
+):
     """Create a BankBranchResolverResponse for the specified API version"""
     # Bank API only available from 2023-09-01.
     # Note that the payload itself changed in 2025-01-01: `branch` holds an
@@ -244,13 +244,13 @@ def create_bank_branch_resolver_response(
 
 
 def create_invoice_issuer_resolver_response(
-    data: Dict[str, Any], api_version: Optional[APIVersion] = None
-) -> Union[
-    v20240101.NTAQualifiedInvoiceIssuerInfoResolverResponse,
-    v20250101.NTAQualifiedInvoiceIssuerInfoResolverResponse,
-    v20260801.NTAQualifiedInvoiceIssuerInfoResolverResponse,
-    compatible.NTAQualifiedInvoiceIssuerInfoResolverResponse,
-]:
+    data: dict[str, Any], api_version: APIVersion | None = None
+) -> (
+    v20240101.NTAQualifiedInvoiceIssuerInfoResolverResponse
+    | v20250101.NTAQualifiedInvoiceIssuerInfoResolverResponse
+    | v20260801.NTAQualifiedInvoiceIssuerInfoResolverResponse
+    | compatible.NTAQualifiedInvoiceIssuerInfoResolverResponse
+):
     """Create a NTAQualifiedInvoiceIssuerInfoResolverResponse for the version"""
     # Invoice API only available from 2024-01-01
     if api_version == "2024-01-01":
@@ -266,7 +266,7 @@ def create_invoice_issuer_resolver_response(
 
 
 def create_school_resolver_response(
-    data: Dict[str, Any], api_version: Optional[APIVersion] = None
+    data: dict[str, Any], api_version: APIVersion | None = None
 ) -> v20250101.SchoolResolverResponse:
     """Create a SchoolResolverResponse for the specified API version"""
     # School API only available from 2025-01-01
@@ -277,7 +277,7 @@ def create_school_resolver_response(
 
 
 def create_school_searcher_response(
-    data: Dict[str, Any], api_version: Optional[APIVersion] = None
+    data: dict[str, Any], api_version: APIVersion | None = None
 ) -> v20250101.SchoolSearcherResponse:
     """Create a SchoolSearcherResponse for the specified API version"""
     # School API only available from 2025-01-01

--- a/kenallclient/models/v20221101.py
+++ b/kenallclient/models/v20221101.py
@@ -1,7 +1,7 @@
 """Models for API version 2022-11-01"""
 
 import dataclasses
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 __all__ = [
     "Address",
@@ -20,12 +20,12 @@ class Corporation:
     name: str
     name_kana: str
     block_lot: str
-    block_lot_num: Optional[str]
+    block_lot_num: str | None
     post_office: str
     code_type: int
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "Corporation":
+    def fromdict(cls, d: dict[str, Any]) -> "Corporation":
         return cls(**d)
 
 
@@ -52,7 +52,7 @@ class Address:
     town_chome: bool
     town_multi: bool
     town_raw: str
-    corporation: Optional[Corporation]
+    corporation: Corporation | None
     # New fields in v2022-11-01
     prefecture_roman: str
     city_roman: str
@@ -71,7 +71,7 @@ class Address:
     update_reason: int
 
     @classmethod
-    def fromdict(cls, i: Dict[str, Any]) -> "Address":
+    def fromdict(cls, i: dict[str, Any]) -> "Address":
         if i.get("corporation"):
             i = dict(i)
             i["corporation"] = Corporation.fromdict(i["corporation"])
@@ -83,10 +83,10 @@ class AddressResolverResponse:
     """Address resolver response for v2022-11-01"""
 
     version: str
-    data: List[Address]
+    data: list[Address]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "AddressResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "AddressResolverResponse":
         data = [Address.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)
 
@@ -96,15 +96,15 @@ class AddressSearcherResponse:
     """Address searcher response for v2022-11-01"""
 
     version: str
-    data: List[Address]
+    data: list[Address]
     query: str
     count: int
-    offset: Optional[int]
-    limit: Optional[int]
-    facets: Optional[List[Tuple[str, int]]]
+    offset: int | None
+    limit: int | None
+    facets: list[tuple[str, int]] | None
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "AddressSearcherResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "AddressSearcherResponse":
         data = [Address.fromdict(i) for i in d["data"]]
         dd = dict(d)
         dd["data"] = data
@@ -130,7 +130,7 @@ class City:
     city_roman: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "City":
+    def fromdict(cls, d: dict[str, Any]) -> "City":
         return cls(**d)
 
 
@@ -139,9 +139,9 @@ class CityResolverResponse:
     """City resolver response for v2022-11-01"""
 
     version: str
-    data: List[City]
+    data: list[City]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "CityResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "CityResolverResponse":
         data = [City.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)

--- a/kenallclient/models/v20230901.py
+++ b/kenallclient/models/v20230901.py
@@ -1,7 +1,7 @@
 """Models for API version 2023-09-01"""
 
 import dataclasses
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 __all__ = [
     "Corporation",
@@ -29,12 +29,12 @@ class Corporation:
     name: str
     name_kana: str
     block_lot: str
-    block_lot_num: Optional[str]
+    block_lot_num: str | None
     post_office: str
     code_type: int
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "Corporation":
+    def fromdict(cls, d: dict[str, Any]) -> "Corporation":
         return cls(**d)
 
 
@@ -61,7 +61,7 @@ class Address:
     town_chome: bool
     town_multi: bool
     town_raw: str
-    corporation: Optional[Corporation]
+    corporation: Corporation | None
     # New fields in v2022-11-01
     prefecture_roman: str
     city_roman: str
@@ -80,7 +80,7 @@ class Address:
     update_reason: int
 
     @classmethod
-    def fromdict(cls, i: Dict[str, Any]) -> "Address":
+    def fromdict(cls, i: dict[str, Any]) -> "Address":
         if i.get("corporation"):
             i = dict(i)
             i["corporation"] = Corporation.fromdict(i["corporation"])
@@ -92,10 +92,10 @@ class AddressResolverResponse:
     """Address resolver response for v2022-11-01"""
 
     version: str
-    data: List[Address]
+    data: list[Address]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "AddressResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "AddressResolverResponse":
         data = [Address.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)
 
@@ -105,15 +105,15 @@ class AddressSearcherResponse:
     """Address searcher response for v2022-11-01"""
 
     version: str
-    data: List[Address]
+    data: list[Address]
     query: str
     count: int
-    offset: Optional[int]
-    limit: Optional[int]
-    facets: Optional[List[Tuple[str, int]]]
+    offset: int | None
+    limit: int | None
+    facets: list[tuple[str, int]] | None
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "AddressSearcherResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "AddressSearcherResponse":
         data = [Address.fromdict(i) for i in d["data"]]
         dd = dict(d)
         dd["data"] = data
@@ -144,7 +144,7 @@ class City:
     city_without_county_and_ward_roman: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "City":
+    def fromdict(cls, d: dict[str, Any]) -> "City":
         return cls(**d)
 
 
@@ -153,10 +153,10 @@ class CityResolverResponse:
     """City resolver response for v2022-11-01"""
 
     version: str
-    data: List[City]
+    data: list[City]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "CityResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "CityResolverResponse":
         data = [City.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)
 
@@ -173,7 +173,7 @@ class Bank:
     romaji: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "Bank":
+    def fromdict(cls, d: dict[str, Any]) -> "Bank":
         return cls(**d)
 
 
@@ -188,7 +188,7 @@ class BankBranch:
     romaji: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranch":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranch":
         return cls(**d)
 
 
@@ -197,10 +197,10 @@ class BanksResponse:
     """Banks response for v2023-09-01"""
 
     version: str
-    data: List[Bank]
+    data: list[Bank]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BanksResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BanksResponse":
         data = [Bank.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)
 
@@ -213,7 +213,7 @@ class BankResolverResponse:
     data: Bank
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BankResolverResponse":
         return cls(version=d["version"], data=Bank.fromdict(d["data"]))
 
 
@@ -222,10 +222,10 @@ class BankBranchesData:
     """Nested data structure for bank branches response in v2023-09-01"""
 
     bank: Bank
-    branches: Dict[str, BankBranch]
+    branches: dict[str, BankBranch]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranchesData":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranchesData":
         bank = Bank.fromdict(d["bank"])
         branches = {
             code: BankBranch.fromdict(branch) for code, branch in d["branches"].items()
@@ -241,7 +241,7 @@ class BankBranchesResponse:
     data: BankBranchesData
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranchesResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranchesResponse":
         data = BankBranchesData.fromdict(d["data"])
         return cls(version=d["version"], data=data)
 
@@ -254,7 +254,7 @@ class BankBranchData:
     branch: BankBranch
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranchData":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranchData":
         bank = Bank.fromdict(d["bank"])
         branch = BankBranch.fromdict(d["branch"])
         return cls(bank=bank, branch=branch)
@@ -268,6 +268,6 @@ class BankBranchResolverResponse:
     data: BankBranchData
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranchResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranchResolverResponse":
         data = BankBranchData.fromdict(d["data"])
         return cls(version=d["version"], data=data)

--- a/kenallclient/models/v20240101.py
+++ b/kenallclient/models/v20240101.py
@@ -1,7 +1,7 @@
 """Models for API version 2024-01-01"""
 
 import dataclasses
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 __all__ = [
     "Address",
@@ -36,12 +36,12 @@ class Corporation:
     name: str
     name_kana: str
     block_lot: str
-    block_lot_num: Optional[str]
+    block_lot_num: str | None
     post_office: str
     code_type: int
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "Corporation":
+    def fromdict(cls, d: dict[str, Any]) -> "Corporation":
         return cls(**d)
 
 
@@ -68,7 +68,7 @@ class Address:
     town_chome: bool
     town_multi: bool
     town_raw: str
-    corporation: Optional[Corporation]
+    corporation: Corporation | None
     # New fields in v2022-11-01
     prefecture_roman: str
     city_roman: str
@@ -87,7 +87,7 @@ class Address:
     update_reason: int
 
     @classmethod
-    def fromdict(cls, i: Dict[str, Any]) -> "Address":
+    def fromdict(cls, i: dict[str, Any]) -> "Address":
         if i.get("corporation"):
             i = dict(i)
             i["corporation"] = Corporation.fromdict(i["corporation"])
@@ -99,10 +99,10 @@ class AddressResolverResponse:
     """Address resolver response for v2022-11-01"""
 
     version: str
-    data: List[Address]
+    data: list[Address]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "AddressResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "AddressResolverResponse":
         data = [Address.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)
 
@@ -112,15 +112,15 @@ class AddressSearcherResponse:
     """Address searcher response for v2022-11-01"""
 
     version: str
-    data: List[Address]
+    data: list[Address]
     query: str
     count: int
-    offset: Optional[int]
-    limit: Optional[int]
-    facets: Optional[List[Tuple[str, int]]]
+    offset: int | None
+    limit: int | None
+    facets: list[tuple[str, int]] | None
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "AddressSearcherResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "AddressSearcherResponse":
         data = [Address.fromdict(i) for i in d["data"]]
         dd = dict(d)
         dd["data"] = data
@@ -149,7 +149,7 @@ class City:
     city_without_county_and_ward_roman: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "City":
+    def fromdict(cls, d: dict[str, Any]) -> "City":
         return cls(**d)
 
 
@@ -158,10 +158,10 @@ class CityResolverResponse:
     """City resolver response for v2022-11-01"""
 
     version: str
-    data: List[City]
+    data: list[City]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "CityResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "CityResolverResponse":
         data = [City.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)
 
@@ -186,7 +186,7 @@ class NTAEntityAddress:
     floor_room: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTAEntityAddress":
+    def fromdict(cls, d: dict[str, Any]) -> "NTAEntityAddress":
         return cls(**d)
 
 
@@ -201,27 +201,27 @@ class NTACorporateInfo:
     update_date: str
     change_date: str
     name: str
-    name_image_id: Optional[str]
+    name_image_id: str | None
     kind: int
     published_date: str
     hihyoji: int
     furigana: str
-    en_address_outside: Optional[str]
-    en_address_line: Optional[str]
+    en_address_outside: str | None
+    en_address_line: str | None
     en_name: str
     assignment_date: str
     change_cause: str
-    successor_corporate_number: Optional[str]
-    close_cause: Optional[str]
-    close_date: Optional[str]
-    address_outside_image_id: Optional[str]
+    successor_corporate_number: str | None
+    close_cause: str | None
+    close_date: str | None
+    address_outside_image_id: str | None
     address_outside: str
-    address_image_id: Optional[str]
-    qualified_invoice_issuer_number: Optional[str]
+    address_image_id: str | None
+    qualified_invoice_issuer_number: str | None
     address: NTAEntityAddress
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTACorporateInfo":
+    def fromdict(cls, d: dict[str, Any]) -> "NTACorporateInfo":
         dd = dict(d)
         if dd.get("address"):
             dd["address"] = NTAEntityAddress.fromdict(dd["address"])
@@ -236,18 +236,18 @@ class NTACorporateInfoResolverResponse:
     data: NTACorporateInfo
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTACorporateInfoResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "NTACorporateInfoResolverResponse":
         return cls(version=d["version"], data=NTACorporateInfo.fromdict(d["data"]))
 
 
 @dataclasses.dataclass()
 class NTACorporateInfoFacetResults:
-    area: Optional[List[Tuple[str, int]]]
-    kind: Optional[List[Tuple[str, int]]]
-    process: Optional[List[Tuple[str, int]]]
-    close_cause: Optional[List[Tuple[str, int]]]
+    area: list[tuple[str, int]] | None
+    kind: list[tuple[str, int]] | None
+    process: list[tuple[str, int]] | None
+    close_cause: list[tuple[str, int]] | None
 
-    def __getitem__(self, v: Any) -> List[Tuple[str, int]]:
+    def __getitem__(self, v: Any) -> list[tuple[str, int]]:
         if v == "area":
             if self.area is not None:
                 return self.area
@@ -274,7 +274,7 @@ class NTACorporateInfoFacetResults:
         return False
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTACorporateInfoFacetResults":
+    def fromdict(cls, d: dict[str, Any]) -> "NTACorporateInfoFacetResults":
         return cls(
             area=[tuple(pair) for pair in d["area"]] if "area" in d else None,
             kind=[tuple(pair) for pair in d["kind"]] if "kind" in d else None,
@@ -290,7 +290,7 @@ class NTACorporateInfoSearcherResponse:
     """Corporate info searcher response for v2024-01-01"""
 
     version: str
-    data: List[str]
+    data: list[str]
     query: str
     count: int
     offset: int
@@ -298,7 +298,7 @@ class NTACorporateInfoSearcherResponse:
     facets: NTACorporateInfoFacetResults
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTACorporateInfoSearcherResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "NTACorporateInfoSearcherResponse":
         dd = dict(d)
         dd["data"] = [NTACorporateInfo.fromdict(i) for i in dd["data"]]
         dd["facets"] = NTACorporateInfoFacetResults.fromdict(dd.get("facets") or {})
@@ -317,7 +317,7 @@ class Bank:
     romaji: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "Bank":
+    def fromdict(cls, d: dict[str, Any]) -> "Bank":
         return cls(**d)
 
 
@@ -332,7 +332,7 @@ class BankBranch:
     romaji: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranch":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranch":
         return cls(**d)
 
 
@@ -341,10 +341,10 @@ class BanksResponse:
     """Banks response for v2023-09-01"""
 
     version: str
-    data: List[Bank]
+    data: list[Bank]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BanksResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BanksResponse":
         data = [Bank.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)
 
@@ -357,7 +357,7 @@ class BankResolverResponse:
     data: Bank
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BankResolverResponse":
         return cls(version=d["version"], data=Bank.fromdict(d["data"]))
 
 
@@ -366,10 +366,10 @@ class BankBranchesData:
     """Nested data structure for bank branches response in v2024-01-01"""
 
     bank: Bank
-    branches: Dict[str, BankBranch]
+    branches: dict[str, BankBranch]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranchesData":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranchesData":
         bank = Bank.fromdict(d["bank"])
         branches = {
             code: BankBranch.fromdict(branch) for code, branch in d["branches"].items()
@@ -385,7 +385,7 @@ class BankBranchesResponse:
     data: BankBranchesData
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranchesResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranchesResponse":
         data = BankBranchesData.fromdict(d["data"])
         return cls(version=d["version"], data=data)
 
@@ -398,7 +398,7 @@ class BankBranchData:
     branch: BankBranch
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranchData":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranchData":
         bank = Bank.fromdict(d["bank"])
         branch = BankBranch.fromdict(d["branch"])
         return cls(bank=bank, branch=branch)
@@ -412,7 +412,7 @@ class BankBranchResolverResponse:
     data: BankBranchData
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranchResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranchResolverResponse":
         data = BankBranchData.fromdict(d["data"])
         return cls(version=d["version"], data=data)
 
@@ -423,26 +423,26 @@ class NTAQualifiedInvoiceIssuerInfo:
 
     published_date: str
     sequence_number: int
-    qualified_invoice_issuer_number: Optional[str]
+    qualified_invoice_issuer_number: str | None
     process: int
-    correct: Optional[int]
+    correct: int | None
     kind: int
     country: int
     latest: int
     registration_date: str
     update_date: str
     disposal_date: str
-    expire_date: Optional[str]
+    expire_date: str | None
     name: str
-    kana: Optional[str]
-    trade_name: Optional[str]
-    popular_name_previous_name: Optional[str]
-    address_inside: Optional[NTAEntityAddress]
-    address_request: Optional[NTAEntityAddress]
-    address: Optional[NTAEntityAddress]
+    kana: str | None
+    trade_name: str | None
+    popular_name_previous_name: str | None
+    address_inside: NTAEntityAddress | None
+    address_request: NTAEntityAddress | None
+    address: NTAEntityAddress | None
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTAQualifiedInvoiceIssuerInfo":
+    def fromdict(cls, d: dict[str, Any]) -> "NTAQualifiedInvoiceIssuerInfo":
         dd = dict(d)
         if dd.get("address_inside"):
             dd["address_inside"] = NTAEntityAddress.fromdict(dd["address_inside"])
@@ -462,7 +462,7 @@ class NTAQualifiedInvoiceIssuerInfoResolverResponse:
 
     @classmethod
     def fromdict(
-        cls, d: Dict[str, Any]
+        cls, d: dict[str, Any]
     ) -> "NTAQualifiedInvoiceIssuerInfoResolverResponse":
         return cls(
             version=d["version"], data=NTAQualifiedInvoiceIssuerInfo.fromdict(d["data"])

--- a/kenallclient/models/v20250101.py
+++ b/kenallclient/models/v20250101.py
@@ -1,7 +1,7 @@
 """Models for API version 2025-01-01"""
 
 import dataclasses
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 __all__ = [
     "Address",
@@ -40,12 +40,12 @@ class Corporation:
     name: str
     name_kana: str
     block_lot: str
-    block_lot_num: Optional[str]
+    block_lot_num: str | None
     post_office: str
     code_type: int
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "Corporation":
+    def fromdict(cls, d: dict[str, Any]) -> "Corporation":
         return cls(**d)
 
 
@@ -72,7 +72,7 @@ class Address:
     town_chome: bool
     town_multi: bool
     town_raw: str
-    corporation: Optional[Corporation]
+    corporation: Corporation | None
     # New fields in v2022-11-01
     prefecture_roman: str
     city_roman: str
@@ -91,7 +91,7 @@ class Address:
     update_reason: int
 
     @classmethod
-    def fromdict(cls, i: Dict[str, Any]) -> "Address":
+    def fromdict(cls, i: dict[str, Any]) -> "Address":
         if i.get("corporation"):
             i = dict(i)
             i["corporation"] = Corporation.fromdict(i["corporation"])
@@ -103,10 +103,10 @@ class AddressResolverResponse:
     """Address resolver response for v2022-11-01"""
 
     version: str
-    data: List[Address]
+    data: list[Address]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "AddressResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "AddressResolverResponse":
         data = [Address.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)
 
@@ -116,15 +116,15 @@ class AddressSearcherResponse:
     """Address searcher response for v2022-11-01"""
 
     version: str
-    data: List[Address]
+    data: list[Address]
     query: str
     count: int
-    offset: Optional[int]
-    limit: Optional[int]
-    facets: Optional[List[Tuple[str, int]]]
+    offset: int | None
+    limit: int | None
+    facets: list[tuple[str, int]] | None
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "AddressSearcherResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "AddressSearcherResponse":
         data = [Address.fromdict(i) for i in d["data"]]
         dd = dict(d)
         dd["data"] = data
@@ -153,7 +153,7 @@ class City:
     city_without_county_and_ward_roman: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "City":
+    def fromdict(cls, d: dict[str, Any]) -> "City":
         return cls(**d)
 
 
@@ -162,10 +162,10 @@ class CityResolverResponse:
     """City resolver response for v2022-11-01"""
 
     version: str
-    data: List[City]
+    data: list[City]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "CityResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "CityResolverResponse":
         data = [City.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)
 
@@ -182,7 +182,7 @@ class Bank:
     romaji: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "Bank":
+    def fromdict(cls, d: dict[str, Any]) -> "Bank":
         return cls(**d)
 
 
@@ -197,7 +197,7 @@ class BankBranch:
     romaji: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranch":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranch":
         return cls(**d)
 
 
@@ -206,10 +206,10 @@ class BanksResponse:
     """Banks response for v2023-09-01"""
 
     version: str
-    data: List[Bank]
+    data: list[Bank]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BanksResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BanksResponse":
         data = [Bank.fromdict(i) for i in d["data"]]
         return cls(version=d["version"], data=data)
 
@@ -222,7 +222,7 @@ class BankResolverResponse:
     data: Bank
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BankResolverResponse":
         return cls(version=d["version"], data=Bank.fromdict(d["data"]))
 
 
@@ -231,10 +231,10 @@ class BankBranchesData:
     """Nested data structure for bank branches response in v2025-01-01"""
 
     bank: Bank
-    branches: Dict[str, List[BankBranch]]
+    branches: dict[str, list[BankBranch]]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranchesData":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranchesData":
         bank = Bank.fromdict(d["bank"])
         branches = {
             code: [BankBranch.fromdict(b) for b in branch_list]
@@ -251,7 +251,7 @@ class BankBranchesResponse:
     data: BankBranchesData
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranchesResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranchesResponse":
         data = BankBranchesData.fromdict(d["data"])
         return cls(version=d["version"], data=data)
 
@@ -261,10 +261,10 @@ class BankBranchData:
     """Nested data structure for bank branch resolver response in v2025-01-01"""
 
     bank: Bank
-    branch: List[BankBranch]
+    branch: list[BankBranch]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranchData":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranchData":
         bank = Bank.fromdict(d["bank"])
         branch = [BankBranch.fromdict(b) for b in d["branch"]]
         return cls(bank=bank, branch=branch)
@@ -278,7 +278,7 @@ class BankBranchResolverResponse:
     data: BankBranchData
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "BankBranchResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "BankBranchResolverResponse":
         data = BankBranchData.fromdict(d["data"])
         return cls(version=d["version"], data=data)
 
@@ -304,7 +304,7 @@ class NTAEntityAddress:
     floor_room: str
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTAEntityAddress":
+    def fromdict(cls, d: dict[str, Any]) -> "NTAEntityAddress":
         return cls(**d)
 
 
@@ -314,26 +314,26 @@ class NTAQualifiedInvoiceIssuerInfo:
 
     published_date: str
     sequence_number: int
-    qualified_invoice_issuer_number: Optional[str]
+    qualified_invoice_issuer_number: str | None
     process: int
-    correct: Optional[int]
+    correct: int | None
     kind: int
     country: int
     latest: int
     registration_date: str
     update_date: str
     disposal_date: str
-    expire_date: Optional[str]
+    expire_date: str | None
     name: str
-    kana: Optional[str]
-    trade_name: Optional[str]
-    popular_name_previous_name: Optional[str]
-    address_inside: Optional[NTAEntityAddress]
-    address_request: Optional[NTAEntityAddress]
-    address: Optional[NTAEntityAddress]
+    kana: str | None
+    trade_name: str | None
+    popular_name_previous_name: str | None
+    address_inside: NTAEntityAddress | None
+    address_request: NTAEntityAddress | None
+    address: NTAEntityAddress | None
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTAQualifiedInvoiceIssuerInfo":
+    def fromdict(cls, d: dict[str, Any]) -> "NTAQualifiedInvoiceIssuerInfo":
         dd = dict(d)
         if dd.get("address_inside"):
             dd["address_inside"] = NTAEntityAddress.fromdict(dd["address_inside"])
@@ -353,7 +353,7 @@ class NTAQualifiedInvoiceIssuerInfoResolverResponse:
 
     @classmethod
     def fromdict(
-        cls, d: Dict[str, Any]
+        cls, d: dict[str, Any]
     ) -> "NTAQualifiedInvoiceIssuerInfoResolverResponse":
         return cls(
             version=d["version"], data=NTAQualifiedInvoiceIssuerInfo.fromdict(d["data"])
@@ -371,27 +371,27 @@ class NTACorporateInfo:
     update_date: str
     change_date: str
     name: str
-    name_image_id: Optional[str]
+    name_image_id: str | None
     kind: int
     published_date: str
     hihyoji: int
     furigana: str
-    en_address_outside: Optional[str]
-    en_address_line: Optional[str]
+    en_address_outside: str | None
+    en_address_line: str | None
     en_name: str
     assignment_date: str
     change_cause: str
-    successor_corporate_number: Optional[str]
-    close_cause: Optional[int]  # Changed from Optional[str] to Optional[int]
-    close_date: Optional[str]
-    address_outside_image_id: Optional[str]
+    successor_corporate_number: str | None
+    close_cause: int | None  # Changed from Optional[str] to Optional[int]
+    close_date: str | None
+    address_outside_image_id: str | None
     address_outside: str
-    address_image_id: Optional[str]
-    qualified_invoice_issuer_number: Optional[str]
+    address_image_id: str | None
+    qualified_invoice_issuer_number: str | None
     address: NTAEntityAddress
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTACorporateInfo":
+    def fromdict(cls, d: dict[str, Any]) -> "NTACorporateInfo":
         dd = dict(d)
         if dd.get("address"):
             dd["address"] = NTAEntityAddress.fromdict(dd["address"])
@@ -406,18 +406,18 @@ class NTACorporateInfoResolverResponse:
     data: NTACorporateInfo
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTACorporateInfoResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "NTACorporateInfoResolverResponse":
         return cls(version=d["version"], data=NTACorporateInfo.fromdict(d["data"]))
 
 
 @dataclasses.dataclass()
 class NTACorporateInfoFacetResults:
-    area: Optional[List[Tuple[str, int]]]
-    kind: Optional[List[Tuple[str, int]]]
-    process: Optional[List[Tuple[str, int]]]
-    close_cause: Optional[List[Tuple[str, int]]]
+    area: list[tuple[str, int]] | None
+    kind: list[tuple[str, int]] | None
+    process: list[tuple[str, int]] | None
+    close_cause: list[tuple[str, int]] | None
 
-    def __getitem__(self, v: Any) -> List[Tuple[str, int]]:
+    def __getitem__(self, v: Any) -> list[tuple[str, int]]:
         if v == "area":
             if self.area is not None:
                 return self.area
@@ -444,7 +444,7 @@ class NTACorporateInfoFacetResults:
         return False
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTACorporateInfoFacetResults":
+    def fromdict(cls, d: dict[str, Any]) -> "NTACorporateInfoFacetResults":
         return cls(
             area=[tuple(pair) for pair in d["area"]] if "area" in d else None,
             kind=[tuple(pair) for pair in d["kind"]] if "kind" in d else None,
@@ -460,7 +460,7 @@ class NTACorporateInfoSearcherResponse:
     """Corporate info searcher response for v2025-01-01"""
 
     version: str
-    data: List[str]
+    data: list[str]
     query: str
     count: int
     offset: int
@@ -468,7 +468,7 @@ class NTACorporateInfoSearcherResponse:
     facets: NTACorporateInfoFacetResults
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "NTACorporateInfoSearcherResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "NTACorporateInfoSearcherResponse":
         dd = dict(d)
         dd["data"] = [NTACorporateInfo.fromdict(i) for i in dd["data"]]
         dd["facets"] = NTACorporateInfoFacetResults.fromdict(dd.get("facets") or {})
@@ -487,14 +487,14 @@ class School:
     establishment_type: int
     branch: int
     address_raw: str
-    addresses: List[NTAEntityAddress]
+    addresses: list[NTAEntityAddress]
     established_date: str
-    abolished_date: Optional[str]
-    school_survey_number: Optional[str]
-    new_code: List[str]
+    abolished_date: str | None
+    school_survey_number: str | None
+    new_code: list[str]
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "School":
+    def fromdict(cls, d: dict[str, Any]) -> "School":
         dd = dict(d)
         if dd.get("addresses"):
             dd["addresses"] = [
@@ -511,18 +511,18 @@ class SchoolResolverResponse:
     data: School
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "SchoolResolverResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "SchoolResolverResponse":
         return cls(version=d["version"], data=School.fromdict(d["data"]))
 
 
 @dataclasses.dataclass()
 class SchoolFacetResults:
-    area: Optional[List[Tuple[str, int]]]
-    type: Optional[List[Tuple[str, int]]]
-    establishment_type: Optional[List[Tuple[str, int]]]
-    branch: Optional[List[Tuple[str, int]]]
+    area: list[tuple[str, int]] | None
+    type: list[tuple[str, int]] | None
+    establishment_type: list[tuple[str, int]] | None
+    branch: list[tuple[str, int]] | None
 
-    def __getitem__(self, v: Any) -> List[Tuple[str, int]]:
+    def __getitem__(self, v: Any) -> list[tuple[str, int]]:
         if v == "area":
             if self.area is not None:
                 return self.area
@@ -549,7 +549,7 @@ class SchoolFacetResults:
         return False
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "SchoolFacetResults":
+    def fromdict(cls, d: dict[str, Any]) -> "SchoolFacetResults":
         return cls(
             area=[tuple(pair) for pair in d["area"]] if "area" in d else None,
             type=[tuple(pair) for pair in d["type"]] if "type" in d else None,
@@ -565,15 +565,15 @@ class SchoolSearcherResponse:
     """School searcher response for v2025-01-01"""
 
     version: str
-    data: List[School]
+    data: list[School]
     query: str
     count: int
     offset: int
     limit: int
-    facets: Optional[SchoolFacetResults]
+    facets: SchoolFacetResults | None
 
     @classmethod
-    def fromdict(cls, d: Dict[str, Any]) -> "SchoolSearcherResponse":
+    def fromdict(cls, d: dict[str, Any]) -> "SchoolSearcherResponse":
         dd = dict(d)
         dd["data"] = [School.fromdict(i) for i in dd["data"]]
         dd["facets"] = SchoolFacetResults.fromdict(dd.get("facets") or {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ check = [
 
 [tool.ruff]
 line-length = 88
-target-version = "py37"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Summary

`[tool.ruff] target-version` was still pinned to `py37` long after the supported floor moved. #18 raised the floor to `requires-python = ">=3.11"` but deliberately left the pin alone to keep that PR reviewable — this is the follow-up that finishes the job.

The pin was load-bearing: ruff infers the target from `requires-python` only when `target-version` is absent, so the stale `py37` was the sole thing suppressing pyupgrade's PEP 585/604 rules. Bumping it to `py311` surfaces 588 findings, all mechanical:

| Rule | Count | Change |
|---|---|---|
| UP045 | 360 | `Optional[X]` → `X \| None` |
| UP006 | 197 | `Dict`/`List`/`Type` → `dict`/`list`/`type` |
| UP035 | 21 | deprecated `typing` imports |
| UP007 | 10 | `Union[...]` → `\|` |

All were resolved by `ruff check --fix`. `ruff format` then rewrapped two files whose unions no longer fit in 88 columns — `client.py`'s multi-version return types are the bulk of it, e.g.

```python
) -> (
    v20221101.AddressResolverResponse
    | v20230901.AddressResolverResponse
    | ...
):
```

Net: 555 insertions, 562 deletions across 8 files.

## Test plan

- `hatch run lint:check` — `ruff check`, `ruff format --check`, and `mypy` (13 source files) all clean
- `hatch run test:run` — 154 passed

No behavioral change. I filtered the diff for anything that is not an annotation rewrite; there is nothing.

## Review note

`kenallclient/models/v20260801.py` (added by #17) is absent from the diff. That is not an exclusion bug — the file was already written with modern annotations, so it had no findings.

Best reviewed with whitespace changes hidden, or commit-by-commit — it is a single mechanical commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
